### PR TITLE
feat: Enable JSX transform

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -145,6 +145,8 @@ module.exports = {
         'plugin:react/recommended',
         // Ref: https://www.npmjs.com/package/eslint-plugin-react-hooks
         'plugin:react-hooks/recommended',
+        // Ref: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports
+        'plugin:react/jsx-runtime',
       ],
       settings: {
         react: {

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+npx tsc --noEmit
 
 if git diff --cached --name-only | grep -q configs; then
   npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@propertyguru/eslint-config-pg",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@propertyguru/eslint-config-pg",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
+        "@types/react": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "eslint": "^8.45.0",
@@ -200,6 +201,29 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.15.tgz",
+      "integrity": "sha512-oEjE7TQt1fFTFSbf8kkNuc798ahTUzn3Le67/PWjE8MAfYAD/qB7O8hSTcromLFqHCt9bcdOg5GXMokzTjJ5SA==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -807,6 +831,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@propertyguru:registry": "https://npm.pkg.github.com/propertyguru"
   },
   "devDependencies": {
+    "@types/react": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.45.0",

--- a/src/react/example.tsx
+++ b/src/react/example.tsx
@@ -1,0 +1,5 @@
+// Test new JSX transform in React 17.
+// Ref: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports
+export default function App() {
+  return <h1>Hello World</h1>
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // Make type as `any` throw error when transpile code.
     "noImplicitAny": true,
     "noEmit": false,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": "./src"
   }
 }


### PR DESCRIPTION
This PR can make React component can created without need to import React.
https://github.com/propertyguru/eslint-config-pg/blob/eb4d98c9cdcadd103fdc3aa50a35addcdb823d49/src/react/example.tsx#L1-L5

It's feature from React 17.
https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports